### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,15 +1,15 @@
 Building Divide.io
 ===========
-##Prerequisites
+## Prerequisites
 You must have git, Maven, and JDK (version 6 or above) installed.
 
-##Step 1
+## Step 1
 Clone the repo:
 
 ```
 git clone https://github.com/HiddenStage/divide.git
 ```
-##Step 2
+## Step 2
 **For OS X:**
 
 Go to the `dependency_setup` directory and run `setup.sh`
@@ -30,7 +30,7 @@ setup.bat
 
 *If you run into ‘cmd’ is not recognized as an internal or external command, make sure you have “C:\Windows\System32” in your Path variable.*
 
-##Step 3
+## Step 3
 Go the the root directory then clean and build the project. (This may take awhile as libraries will download and tests will be run)
 
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Deploy anywhere. Use any database you want. Never get locked into a platform.
 
 Visit [our website](http://www.divide.io/) for more information.
 
-####How does it work?
+#### How does it work?
 Divide.io provides easy to use APIs to connect your mobile app to a backend. Getting up and running is simple.
 
 1. Choose your server provider. Any server that runs Java should suffice.
@@ -20,7 +20,7 @@ Divide.io provides easy to use APIs to connect your mobile app to a backend. Get
 You can now use our APIs to communicate back and forth to your backend. Saving data, querying, registering and logging in users, etc. are now just a few lines of code away!
 
 
-####Getting Started Guides
+#### Getting Started Guides
 **Servers:**
 * [App Engine](http://www.divide.io/get_started/app_engine)
 
@@ -28,13 +28,13 @@ You can now use our APIs to communicate back and forth to your backend. Saving d
 
 * [Android](http://www.divide.io/get_started/android)
 
-####Documentation
+#### Documentation
 
 * [Server docs](http://www.divide.io/docs/server)
 * [Android docs](http://www.divide.io/docs/android)
 * [Javadocs](http://hiddenstage.github.io/divide-docs/javadocs/)
 
-####License
+#### License
 ```
 Copyright (C) 2016 Divide.io
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
